### PR TITLE
allow custom status code for errors

### DIFF
--- a/sanic_validation/decorators.py
+++ b/sanic_validation/decorators.py
@@ -7,7 +7,7 @@ QUERY_ARG_ENTRY_TYPE = 'query_argument'
 REQ_BODY_ENTRY_TYPE = 'request_body'
 
 
-def validate_json(schema, clean=False):
+def validate_json(schema, clean=False, status_code=400):
     '''Decorator. Validates request body json.
 
     When *clean* is true, normalized data is passed to the decorated method
@@ -16,6 +16,8 @@ def validate_json(schema, clean=False):
     Args:
         schema (dict): Cerberus-compatible schema description
         clean (bool): should cleaned json be passed to the decorated method
+        status_code (number): status code to return when data is incorrect,
+        defaults to 400
     '''
     validator = Validator(schema)
 
@@ -31,14 +33,15 @@ def validate_json(schema, clean=False):
                 return f(request, *args, **kwargs)
             else:
                 return _validation_failed_response(validator,
-                                                   JSON_DATA_ENTRY_TYPE)
+                                                   JSON_DATA_ENTRY_TYPE,
+                                                   status_code)
 
         return wrapper
 
     return vd
 
 
-def validate_args(schema, clean=False):
+def validate_args(schema, clean=False, status_code=400):
     '''Decorator. Validates querystring arguments.
 
     When *clean* is True, normalized data is passed to the decorated method
@@ -47,6 +50,7 @@ def validate_args(schema, clean=False):
     Args:
         schema (dict): Cerberus-compatible schema description
         clean (bool): should cleaned args be passed to the decorated method
+        status_code (number): status code to return when data is incorrect,
     '''
     validator = Validator(schema)
 
@@ -60,14 +64,15 @@ def validate_args(schema, clean=False):
                 return f(request, *args, **kwargs)
             else:
                 return _validation_failed_response(validator,
-                                                   QUERY_ARG_ENTRY_TYPE)
+                                                   QUERY_ARG_ENTRY_TYPE,
+                                                   status_code)
 
         return wrapper
 
     return vd
 
 
-def _validation_failed_response(validator, entry_type):
+def _validation_failed_response(validator, entry_type, status_code=400):
     return json(
         {
             'error': {
@@ -76,7 +81,7 @@ def _validation_failed_response(validator, entry_type):
                 'invalid': _validation_failures_list(validator, entry_type)
             }
         },
-        status=400)
+        status=status_code)
 
 
 def _validation_failures_list(validator, entry_type):

--- a/tests/test_error_response_detail.py
+++ b/tests/test_error_response_detail.py
@@ -132,6 +132,43 @@ class TestErrorResponseDetailForJson(unittest.TestCase):
                               self._expected_errors)
 
 
+class TestErrorResponseStatusForJson(unittest.TestCase):
+    _endpoint_schema = {
+        'name': {
+            'type': 'string',
+            'required': True
+        },
+    }
+
+    _params_data = {}
+
+    _expected_errors = [{
+        'entry_type': 'json_data_property',
+        'entry': 'name',
+        'rule': 'required',
+        'constraint': True
+    }]
+
+    def setUp(self):
+        self._app = Sanic()
+
+        @self._app.route('/')
+        @validate_json(self._endpoint_schema, status_code=422)
+        async def _endpoint(request):
+            return json({'status': 'ok'})
+
+    def test_response_should_use_provided_status_code(self):
+        _, response = self._app.test_client.get('/', json=self._params_data)
+
+        self.assertEqual(response.status, 422)
+        self.assertEqual(response.json['error']['message'],
+                         'Validation failed.')
+        self.assertEqual(response.json['error']['type'], 'validation_failed')
+
+        self.assertCountEqual(response.json['error']['invalid'],
+                              self._expected_errors)
+
+
 class TestErrorResponseDetailForParams(unittest.TestCase):
     _endpoint_schema = {
         'name': {
@@ -166,6 +203,43 @@ class TestErrorResponseDetailForParams(unittest.TestCase):
         _, response = self._app.test_client.get('/', params=self._params_data)
 
         self.assertEqual(response.status, 400)
+        self.assertEqual(response.json['error']['message'],
+                         'Validation failed.')
+        self.assertEqual(response.json['error']['type'], 'validation_failed')
+
+        self.assertCountEqual(response.json['error']['invalid'],
+                              self._expected_errors)
+
+
+class TestErrorResponseStatusForParams(unittest.TestCase):
+    _endpoint_schema = {
+        'name': {
+            'type': 'string',
+            'required': True
+        },
+    }
+
+    _params_data = {}
+
+    _expected_errors = [{
+        'entry_type': 'query_argument',
+        'entry': 'name',
+        'rule': 'required',
+        'constraint': True
+    }]
+
+    def setUp(self):
+        self._app = Sanic()
+
+        @self._app.route('/')
+        @validate_args(self._endpoint_schema, status_code=422)
+        async def _endpoint(request):
+            return json({'status': 'ok'})
+
+    def test_response_should_use_provided_status_code(self):
+        _, response = self._app.test_client.get('/', params=self._params_data)
+
+        self.assertEqual(response.status, 422)
         self.assertEqual(response.json['error']['message'],
                          'Validation failed.')
         self.assertEqual(response.json['error']['type'], 'validation_failed')


### PR DESCRIPTION
Driveby PR time 🎉 
I have a suggestion to allow custom status codes when returning errors; not everyone uses 400
(I use 422 😛 )