### PR TITLE
Upgrade sanic version and fix deprecation warning

### DIFF
--- a/sanic_validation/decorators.py
+++ b/sanic_validation/decorators.py
@@ -57,7 +57,7 @@ def validate_args(schema, clean=False, status_code=400):
     def vd(f):
         @wraps(f)
         def wrapper(request, *args, **kwargs):
-            validation_passed = validator.validate(request.raw_args)
+            validation_passed = validator.validate(dict(request.raw_args))
             if validation_passed:
                 if clean:
                     kwargs['valid_args'] = validator.document

--- a/sanic_validation/decorators.py
+++ b/sanic_validation/decorators.py
@@ -57,7 +57,7 @@ def validate_args(schema, clean=False, status_code=400):
     def vd(f):
         @wraps(f)
         def wrapper(request, *args, **kwargs):
-            validation_passed = validator.validate(dict(request.raw_args))
+            validation_passed = validator.validate(dict(request.query_args))
             if validation_passed:
                 if clean:
                     kwargs['valid_args'] = validator.document

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     author='Piotr Bakalarski',
     author_email='piotrb5e3@gmail.com',
     license='GPLv3',
-    install_requires=['sanic>=0.6.0', 'cerberus'],
+    install_requires=['sanic>=19.3.1', 'cerberus'],
     setup_requires=['pytest-runner', 'pytest-flake8'],
     tests_require=['pytest', 'aiohttp', 'flake8'],
     packages=find_packages(),


### PR DESCRIPTION
Newer sanic versions now throw deprecation warning for using `raw_args`, please see [PR](https://github.com/huge-success/sanic/pull/1476).

In particular,

> ```
> C:\Users\user\AppData\Roaming\Python\Python36\site-packages\sanic\request.py:264: DeprecationWarning: Use of raw_args will be deprecated in the future versions. Please use args or query_args properties instead
>   DeprecationWarning,```

So I changed 
`            validation_passed = validator.validate(request.raw_args)
`
to 
`
            validation_passed = validator.validate(dict(request.query_args))
`
It will not solve the problem with repeated arguments but will suppress deprecation warning. Not sure how to pass lists of arguments to the validator.