### PR TITLE
Synced with sanic 20.3.0

### DIFF
--- a/sanic_validation/__init__.py
+++ b/sanic_validation/__init__.py
@@ -2,4 +2,4 @@ from .decorators import validate_json, validate_args
 
 __all__ = [validate_json, validate_args]
 
-__version__ = '0.4.4'
+__version__ = '0.4.5'

--- a/sanic_validation/decorators.py
+++ b/sanic_validation/decorators.py
@@ -56,7 +56,7 @@ def validate_args(schema, clean=False, status_code=400):
     def vd(f):
         @wraps(f)
         def wrapper(request, *args, **kwargs):
-            validation_passed = validator.validate(request.raw_args)
+            validation_passed = validator.validate(dict(request.query_args))
             if validation_passed:
                 if clean:
                     kwargs['valid_args'] = validator.document

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     author='Piotr Bakalarski',
     author_email='piotrb5e3@gmail.com',
     license='GPLv3',
-    install_requires=['sanic>=0.8.3', 'cerberus'],
+    install_requires=['sanic>=19.3.1', 'cerberus'],
     setup_requires=['pytest-runner', 'pytest-flake8'],
     tests_require=['pytest', 'aiohttp', 'flake8'],
     packages=find_packages(),

--- a/tests/test_empty_json.py
+++ b/tests/test_empty_json.py
@@ -13,7 +13,7 @@ class TestEmptyJsonValidation(unittest.TestCase):
     def setUp(self):
         self._app = Sanic()
 
-        @self._app.route('/')
+        @self._app.route('/', methods=["GET", "POST"])
         @validate_json(self._endpoint_schema)
         async def _simple_endpoint(request):
             return text('OK')
@@ -33,6 +33,6 @@ class TestEmptyJsonValidation(unittest.TestCase):
         }])
 
     def test_endpoint_should_accept_empty_json_object(self):
-        _, response = self._app.test_client.get('/', json={})
+        _, response = self._app.test_client.post('/', json={})
         self.assertEqual(response.status, 200)
         self.assertEqual(response.text, 'OK')

--- a/tests/test_error_response_detail.py
+++ b/tests/test_error_response_detail.py
@@ -115,13 +115,13 @@ class TestErrorResponseDetailForJson(unittest.TestCase):
     def setUp(self):
         self._app = Sanic()
 
-        @self._app.route('/')
+        @self._app.route('/', methods=["GET", "POST"])
         @validate_json(self._endpoint_schema)
         async def _endpoint(request):
             return json({'status': 'ok'})
 
     def test_response_should_contain_all_errors(self):
-        _, response = self._app.test_client.get('/', json=self._request_data)
+        _, response = self._app.test_client.post('/', json=self._request_data)
 
         self.assertEqual(response.status, 400)
         self.assertEqual(response.json['error']['message'],
@@ -152,13 +152,13 @@ class TestErrorResponseStatusForJson(unittest.TestCase):
     def setUp(self):
         self._app = Sanic()
 
-        @self._app.route('/')
+        @self._app.route('/', methods=["GET", "POST"])
         @validate_json(self._endpoint_schema, status_code=422)
         async def _endpoint(request):
             return json({'status': 'ok'})
 
     def test_response_should_use_provided_status_code(self):
-        _, response = self._app.test_client.get('/', json=self._params_data)
+        _, response = self._app.test_client.post('/', json=self._params_data)
 
         self.assertEqual(response.status, 422)
         self.assertEqual(response.json['error']['message'],

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -19,13 +19,13 @@ class TestSimpleJSONNormalization(unittest.TestCase):
     def setUp(self):
         self._app = Sanic()
 
-        @self._app.route('/')
+        @self._app.route('/', methods=["GET", "POST"])
         @validate_json(self._endpoint_schema, clean=True)
         async def _simple_endpoint(request, valid_json):
             return json({'req_room_no': valid_json['room_no']})
 
     def test_numeric_string_value_should_normalize_correctly(self):
-        _, response = self._app.test_client.get('/', json={'room_no': '517'})
+        _, response = self._app.test_client.post('/', json={'room_no': '517'})
         self.assertEqual(response.status, 200)
         self.assertEqual(response.json['req_room_no'], 517)
 
@@ -41,7 +41,7 @@ class TestSimpleJSONNormalization(unittest.TestCase):
             'rule': 'type',
             'constraint': 'integer'
         }]
-        _, response = self._app.test_client.get('/', json={'room_no': 'k-1'})
+        _, response = self._app.test_client.post('/', json={'room_no': 'k-1'})
         self.assertEqual(response.status, 400)
         self.assertEqual(response.json['error']['message'],
                          'Validation failed.')

--- a/tests/test_simple_endpoint.py
+++ b/tests/test_simple_endpoint.py
@@ -13,20 +13,20 @@ class TestSimpleEndpointJsonValidation(unittest.TestCase):
     def setUp(self):
         self._app = Sanic()
 
-        @self._app.route('/')
+        @self._app.route('/', methods=["GET", "POST"])
         @validate_json(self._endpoint_schema)
         async def _simple_endpoint(request):
             return json({'status': 'ok'})
 
     def test_should_fail_validation(self):
-        _, response = self._app.test_client.get('/', json={})
+        _, response = self._app.test_client.post('/', json={})
         self.assertEqual(response.status, 400)
         self.assertEqual(response.json['error']['message'],
                          'Validation failed.')
         self.assertEqual(response.json['error']['type'], 'validation_failed')
 
     def test_should_pass_validation(self):
-        _, response = self._app.test_client.get('/', json={'name': 'john'})
+        _, response = self._app.test_client.post('/', json={'name': 'john'})
         self.assertEqual(response.status, 200)
         self.assertEqual(response.json['status'], 'ok')
 


### PR DESCRIPTION
 -  Replaced deprecated request.raw_args usage to request.query_args. 
 - Synced with move to aiohttp client on sanic test client for correct test passing
 - Bump version 0.4.5.